### PR TITLE
Updates Hedgedoc CSC Helm Chart:

### DIFF
--- a/charts/hedgedoc/Chart.yaml
+++ b/charts/hedgedoc/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hedgedoc
 description: Hedgedoc Helm Chart for Rahti platform
   Link to the repo https://github.com/CSCfi/helm-charts
-version: 1.2.1
+version: 1.2.2
 sources:
 - https://github.com/CSCfi/helm-charts
 icon: https://raw.githubusercontent.com/hedgedoc/hedgedoc/develop/frontend/src/app/icon.png

--- a/charts/hedgedoc/README.md
+++ b/charts/hedgedoc/README.md
@@ -52,7 +52,7 @@ By default, this Helm Chart won't deploy a postgreSQL database along Hedgedoc. I
 
 Since we are using the `bitnami/postgresql` Helm Chart as a dependency, you can take a look to the [PostgreSQL ArtifactHub](https://artifacthub.io/packages/helm/bitnami/postgresql/15.5.0) to check the different values.
 
-This parameters is disabled by default. If you want to use a postgresql database among, enable it with `postgresql.enabled`
+This parameter is disabled by default. If you want to use a postgresql database among Hedgedoc deployment on Rahti, enable it with `postgresql.enabled`
 
 
 ### HedgeDoc parameters

--- a/charts/hedgedoc/README.md
+++ b/charts/hedgedoc/README.md
@@ -3,16 +3,24 @@
 ```sh
 helm upgrade --install hedgedoc .
 ```
+## Getting started
+[Helm](helm.sh) and `oc` CLI must be installed on your local machine.
 
-## Explanations
-This Helm Chart helps you to deploy HedgeDoc on CSC Rahti (Openshift 4).  
+## Introduction
+This Helm Chart helps you to deploy HedgeDoc on CSC Rahti (Openshift 4).
+
+It is highly recommended to use the Helm CLI instead of the WebUI of Rahti2. If so, you can clone the GitHub repository from [here](https://github.com/CSCfi/helm-charts).  
+Helm CLI allows you:
+- to download the necessary dependencies in order to run the chart, if you decide to run PostgreSQL in Rahti2.
+- to set the necessary values (see command below), if you decide to run a PostgreSQL instance externally.
+
 If you want to use it with different values, you can edit `values.yaml` file and then run:  
 ```sh
 helm upgrade --install hedgedoc . -f {custom_values.yaml}
 ```
 
-By default, this Helm Chart deployed a postgreSQL database along Hedgedoc. If you want to connect Hedgedoc to an existing external database, you have to enable the parameters
-`postgresqlExternal.enabled` and disable the default one `postgresql.enabled`. More information below in the table.
+By default, this Helm Chart won't deploy a postgreSQL database along Hedgedoc. If you want to connect Hedgedoc to an existing external database, you have to enable the parameters
+`postgresql.enabled` and disable the default one `postgresqlExternal.enabled`. More information below in the table.
 
 ## Parameters
 ### Common parameters
@@ -33,26 +41,31 @@ By default, this Helm Chart deployed a postgreSQL database along Hedgedoc. If yo
 | `hedgedoc.podSecurityContext`          | Set SecurityContext for the pod                         | `{}`                                       |
 | `hedgedoc.containerSecurityContext`    | Set SecurityContext for the container                   | `allowPrivilegeEscalation: false`<br>`runAsUser:`<br>`runAsGroup:`<br>`capabilities:`<br>&nbsp;&nbsp;`drop:`<br>&nbsp;&nbsp;`- ALL`<br>`runAsNonRoot: true`<br>`seccompProfile:`<br>&nbsp;&nbsp;`type: RuntimeDefault` |
 | `hedgedoc.pvc.storageSpace`            | Storage space for the PersistentVolume                  | `5Gi`                                      |
-| `hedgedoc.service.type`                | Set the Service type                                    | `ClusterIP`                                |
 | `hedgedoc.random_pw_secret_key`        | Key to store the password                               | `database-password`                        |
-| `hedgedoc.secret.database-name`        | Name of the database                                    | `postgres`                                 |
-| `hedgedoc.secret.database-user`        | Name of the postgres user                               | `postgres`                                 |
-| `hedgedoc.secret.database-password`    | Function that retrieve the generated password           | `'{{- include "random_pw_reusable" . -}}'` |
+| `hedgedoc.secret.databaseName`         | Name of the database. Linked to `postgresql.auth.database`. EDIT `postgresql.auth.database` instead of this value!                                    | `{{ tpl .Values.postgresql.auth.database . }}` |
+| `hedgedoc.secret.databaseUser`         | Name of the postgres user. Linked to `postgresql.auth.username`. EDIT `postgresql.auth.username` instead of this value!                              | `{{ tpl .Values.postgresql.auth.database . }}` |
+| `hedgedoc.secret.databasePassword`     | Empty by default because the password is generated randomly and stored in a Secret. Replace this value if you want to add your custom password. | `''` |
+| `hedgedoc.secret.password`     | Empty by default because the password is generated randomly and stored in a Secret. Replace this value if you want to add your custom password. | `''` |
+| `hedgedoc.secret.postgresPassword`     | Empty by default because the password is generated randomly and stored in a Secret. Replace this value if you want to add your custom password. | `''` |
 
 ### PostgreSQL parameters
 
 Since we are using the `bitnami/postgresql` Helm Chart as a dependency, you can take a look to the [PostgreSQL ArtifactHub](https://artifacthub.io/packages/helm/bitnami/postgresql/15.5.0) to check the different values.
 
-The postgres database password is generated randomly and won't change if you upgrade the Chart.
+This parameters is disabled by default. If you want to use a postgresql database among, enable it with `postgresql.enabled`
+
 
 ### HedgeDoc parameters
 
-It's possible to use an external database if you have one ready. Here are the parameters:
+By default it will use an external database. Here are the parameters:
 
-| Name                                   | Description                                                          | Value      |
-| -------------------------------------- | -------------------------------------------------------------------- | ---------- |
-| `postgresqlExternal.enabled`           | If you want to use an existing external database                     | `false`    |
-| `postgresqlExternal.externalDatabase`  | If you enable an external, enter its DNS name or public address IP   | ``         |
+| Name                                          | Description                                                          | Value      |
+| --------------------------------------------- | -------------------------------------------------------------------- | -----------|
+| `postgresqlExternal.enabled`                  | If you want to use an existing external database                     | `true`     |
+| `postgresqlExternal.externalDatabase`         | If you are using Pukki, enter its DNS name or public address IP      | `0.0.0.0`  |
+| `postgresqlExternal.secret.database-name`     | If you are using Pukki, enter the database created                   | `hedgedoc` |
+| `postgresqlExternal.secret.database-username` | If you are using Pukki, enter the username created                   | `hedgedoc` |
+| `postgresqlExternal.secret.database-password` | If you are using Pukki, enter the passworc created                   | `hedgedoc` |
 
 ## Cleanup
 To delete all the resources, simply uninstall the Helm Chart:

--- a/charts/hedgedoc/templates/_helpers.tpl
+++ b/charts/hedgedoc/templates/_helpers.tpl
@@ -95,3 +95,21 @@ Define a function that lookup the secret on upgrade. If install, it requires the
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Return PostgreSQL auth database name
+NOTE: This macro is run in both the parent chart and the PostgreSQL
+subchart (as it is used in the init scripts), so we need to control the
+scope
+*/}}
+{{- define "hedgedoc.v0.database-auth.name" -}}
+{{- if .Values.postgresql -}}
+    {{/* Inside parent chart */}}
+    {{- if .Values.postgresql.enabled -}}
+    {{- printf "%s_auth" .Values.postgresql.auth.database -}}
+    {{- end -}}
+{{- else -}}
+    {{/* Inside postgresql sub-chart, therefore postgresql.enabled=true */}}
+    {{- printf "%s_auth" .Values.auth.database -}}
+{{- end -}}
+{{- end -}}

--- a/charts/hedgedoc/templates/secrets.yaml
+++ b/charts/hedgedoc/templates/secrets.yaml
@@ -1,13 +1,29 @@
+{{- if .Values.postgresql.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
   labels:
     app: postgresql
   name: postgres
-{{- if .Values.hedgedoc.secret }}
 data:
-  {{- range $key, $val := .Values.hedgedoc.secret }}
+  database-name: {{ .Values.postgresql.auth.database | b64enc | quote }}
+  database-user: {{ .Values.postgresql.auth.username | b64enc | quote }}
+  database-password: {{ .Values.hedgedoc.secret.databasePassword | default ( include "random_pw_reusable" . ) | b64enc | quote }}
+  password: {{ .Values.hedgedoc.secret.password | default ( include "random_pw_reusable" . ) | b64enc | quote }}
+  postgres-password: {{ .Values.hedgedoc.secret.postgresPassword | default ( include "random_pw_reusable" . ) | b64enc | quote }}
+type: Opaque
+{{- end }}
+
+{{- if not .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: postgresql
+  name: postgres
+data:
+  {{- range $key, $val := .Values.postgresqlExternal.secret }}
     "{{ $key }}": "{{ tpl $val $ | b64enc }}"
   {{- end }}
-{{- end }}
 type: Opaque
+{{- end }}

--- a/charts/hedgedoc/templates/services.yaml
+++ b/charts/hedgedoc/templates/services.yaml
@@ -13,5 +13,5 @@ spec:
     targetPort: 3000
   selector:
     app: hedgedoc
-  type: {{ .Values.hedgedoc.service.type }}
+  type: ClusterIP
 ---

--- a/charts/hedgedoc/values.schema.json
+++ b/charts/hedgedoc/values.schema.json
@@ -65,21 +65,19 @@
                 },
                 "secret": {
                     "properties": {
-                        "database-name": {
+                        "databaseName": {
                             "type": "string"
                         },
-                        "database-password": {
+                        "databasePassword": {
                             "type": "string"
                         },
-                        "database-user": {
+                        "databaseUser": {
                             "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "service": {
-                    "properties": {
-                        "type": {
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "postgresPassword": {
                             "type": "string"
                         }
                     },
@@ -138,6 +136,22 @@
             "properties": {
                 "enabled": {
                     "type": "boolean"
+                },
+                "externalDatabase": {
+                    "type": "string"
+                },
+                "secret": {
+                    "properties": {
+                        "database-name": {
+                            "type": "string"
+                        },
+                        "database-user": {
+                            "type": "string"
+                        },
+                        "database-password": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/charts/hedgedoc/values.yaml
+++ b/charts/hedgedoc/values.yaml
@@ -12,7 +12,7 @@ route:
 hedgedoc:
   appname: my-hedgedoc
   domain: 2.rahtiapp.fi
-  image: quay.io/hedgedoc/hedgedoc:1.9.9
+  image: quay.io/hedgedoc/hedgedoc:1.10.0
   podSecurityContext: {}
   containerSecurityContext:
     allowPrivilegeEscalation: false
@@ -26,20 +26,27 @@ hedgedoc:
       type: RuntimeDefault
   pvc:
     storageSpace: 5Gi
-  service:
-    type: ClusterIP
   random_pw_secret_key: database-password # Used by random_pw_reusable function in _helpers.tpl
+  # HANDLE WITH CARE!!!
+  # These values are not meant to be changed.
+  # If you want to change them, please refer to the comment next to each.
   secret:
-    database-name: postgres
-    database-user: postgres
-    database-password: '{{- include "random_pw_reusable" . -}}'
+    # Needed if postgresql.enabled=true
+    databaseName: '{{ tpl .Values.postgresql.auth.database . }}' # Linked to postgresql.auth.database. EDIT postgresql.auth.database instead of this value!
+    databaseUser: '{{ tpl .Values.postgresql.auth.username . }}' # Linked to postgresql.auth.username. EDIT postgresql.auth.username instead of this value!
+    databasePassword: '' # Empty by default because the password is generated randomly and stored in a Secret. Replace this value if you want to add your custom password.
+    password: '' # Empty by default because the password is generated randomly and stored in a Secret. Replace this value if you want to add your custom password.
+    postgresPassword: '' # Empty by default because the password is generated randomly and stored in a Secret. Replace this value if you want to add your custom password.
 
-# Parameters related to the deployment of PostgreSQL in Rahti
+# Parameters related to the deployment of PostgreSQL in Rahti.
+# The parameters come from bitnami/postgresql dependency (https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
 postgresql:
-  enabled: true
+  enabled: false
 
   auth:
-    enablePostgresUser: false
+    username: hedgedoc
+    database: hedgedoc
+    enablePostgresUser: true
     existingSecret: postgres
 
   tls:
@@ -49,9 +56,21 @@ postgresql:
   compatibility:
     openshift:
       adaptSecurityContext: force
+    ## @param postgresql.primary.initdb.scripts [object] Map with init scripts for the PostgreSQL database
+    initdb:
+      scripts:
+        # For authentication
+        create_auth_db.sh: |
+          #!/bin/bash
+          PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD psql -U postgres <<< "CREATE DATABASE {{ include "hedgedoc.v0.database-auth.name" . }}"
+          PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD psql -U postgres <<< "GRANT ALL PRIVILEGES ON DATABASE {{ include "hedgedoc.v0.database-auth.name" . }} to {{ .Values.auth.username }}"
+          PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD psql -U postgres <<< "ALTER DATABASE {{ include "hedgedoc.v0.database-auth.name" . }} OWNER TO {{ .Values.auth.username }}"
 
 # Parameters related to the deployment of an external PostgreSQL (like Pukki)
 postgresqlExternal:
-  enabled: false
-  # If using an external database, enter the DNS name or public IP
-  externalDatabase:
+  enabled: true
+  externalDatabase: '0.0.0.0' # If using an external database, enter the DNS name or public IP
+  secret:
+    database-name: 'hedgedoc'
+    database-user: 'hedgedoc'
+    database-password: 'hedgedoc'


### PR DESCRIPTION
- Update Hedgedoc image to `1.10.0`
- Update `README`
- Update `Chart.yaml` version
- Update `values.yaml`
  - `postgresql.enabled=false` by default
  - `postgresqlExternal.enabled=true` by default
  - `ClusterIP` service by default for Hedgedoc
  - Update `secrets.yaml` to reflect if we deploy an external database or not.
- Update `values.schema.json`
- Add comments/explanations in `values.yaml`